### PR TITLE
Add brass key that opens office 7

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -5,6 +5,7 @@ Constant FLAG_COUNT = 2;
 Constant F_HAS_LADDER = 0;
 Constant F_HAS_COMPUTER = 1;
 Constant F_HAS_BROCHURE = 0;
+Constant F_HAS_BRASSKEY = 0;
 
 Include "ext_flags.h";
 Include "globals.h";
@@ -57,6 +58,22 @@ with
 s_to Lobby,
 
 has light;
+
+Object -> o7key "loose brass key"
+with
+	name 'key' 'brass',
+	description "This is a single brass key. Stamped on the key are the words ~DUPLICATION STRICTLY PROHIBITED~.",
+	before [;
+		take: 
+			if(FlagIsClear(F_HAS_BRASSKEY)) {
+				SetFlag(F_HAS_BRASSKEY);
+			}
+		drop:
+			if(FlagIsSet(F_HAS_BRASSKEY)) {
+				ClearFlag(F_HAS_BRASSKEY);
+			}
+	];
+
 
 !=============WAITING======================
 Object Waiting "Waiting Room"
@@ -119,6 +136,13 @@ with
 s_to Waiting,
 n_to Hallway6,
 w_to Office7,
+before [;
+		Go:
+			if(selected_direction==w_to) {
+				if(FlagIsClear(F_HAS_BRASSKEY))
+					"The door is locked and likely requires a key.";
+			}
+],
 
 has light;
 

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -37,7 +37,7 @@
 # > l
 # It feels so nice, standing in the box.
 
-* get/drop key
+* loop the hallway
 
 > w
 > n
@@ -48,4 +48,27 @@
 > s
 > s
 > s
-Lobby East
+> w
+The Lobby
+
+* get/drop key from receptionist area
+
+> n
+> get key
+Taken.
+> drop key
+Dropped.
+
+* test o7 with/without key
+
+> n
+> take key
+> s
+> w
+> n
+> w
+> e
+Hallway7
+> drop key
+> w
+The door is locked and likely requires a key.


### PR DESCRIPTION
Added a brass key (now on floor in receptionist office) that allows passage into office 7. Dropping the key unsets the F_HAS_BRASSKEY property, so you need the key to enter the office each time.

It would be nice if you had to manually unlock the door, and then it stayed unlocked unless locked with the key, but this works for now.