### PR TITLE
Flagless

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -1,13 +1,7 @@
 Constant Story "The Office";
 Constant Headline "^It is your first day on the job at Blamazon. You applied here to gain access to their offices after hours to steal the boss's valuable information off of their computer. They have state of the art cyber security preventing any digital leaks of the information so you are here to physically take it.^";
 Constant INITIAL_LOCATION_VALUE = Lobby;
-Constant FLAG_COUNT = 2;
-Constant F_HAS_LADDER = 0;
-Constant F_HAS_COMPUTER = 1;
-Constant F_HAS_BROCHURE = 0;
-Constant F_HAS_BRASSKEY = 0;
 
-Include "ext_flags.h";
 Include "globals.h";
 Include "ext_cheap_scenery.h";
 Include "puny.h";
@@ -62,17 +56,7 @@ has light;
 Object -> o7key "loose brass key"
 with
 	name 'key' 'brass',
-	description "This is a single brass key. Stamped on the key are the words ~DUPLICATION STRICTLY PROHIBITED~.",
-	before [;
-		take: 
-			if(FlagIsClear(F_HAS_BRASSKEY)) {
-				SetFlag(F_HAS_BRASSKEY);
-			}
-		drop:
-			if(FlagIsSet(F_HAS_BRASSKEY)) {
-				ClearFlag(F_HAS_BRASSKEY);
-			}
-	];
+	description "This is a single brass key. Stamped on the key are the words ~DUPLICATION STRICTLY PROHIBITED~.";
 
 
 !=============WAITING======================
@@ -105,13 +89,7 @@ has static supporter;
 Object -> -> brochure "brochure"
 with
 	name "brochure" "flyer" "paper",
-	description "This full-color tri-fold flyer is printed on sturdy paper. It talks in extravagant terms about the company.",
-	before [;
-		take:
-			if(FlagIsClear(F_HAS_BROCHURE)) {
-				SetFlag(F_HAS_BROCHURE);
-			}
-	];
+	description "This full-color tri-fold flyer is printed on sturdy paper. It talks in extravagant terms about the company.";
 	
 
 !=============LOBBYEAST===========
@@ -192,13 +170,7 @@ has light;
 Object -> ladder "ladder"
 with
 	name 'ladder' 'yellow ladder' 'sunflower yellow ladder',
-	description "This ladder is a bright sunflower yellow ladder. It must be used to replace the lights if they burn out, without this accessing the ceiling would be impossible.",
-	before [;
-		take: 
-			if(FlagIsClear(F_HAS_LADDER)) {
-				SetFlag(F_HAS_LADDER);
-			}
-	];
+	description "This ladder is a bright sunflower yellow ladder. It must be used to replace the lights if they burn out, without this accessing the ceiling would be impossible.";
 
 !=============HALLWAY5(~~~~~PLACEHOLDER~~~~~)=======================
 Object Hallway5
@@ -376,7 +348,10 @@ u_to Crawl1,
 before [;
 		Go:
 			if(selected_direction==u_to) {
-				if(FlagIsClear(F_HAS_LADDER))
+				! This should work whether the player is holding the ladder
+				! (it's in the player which is in the SOffice, so transitively
+				! it's in the SOffice), or if the player drops it here.
+				if(ladder notin self)
 					"You cannot get up there, if only you had a some sort of step stool.";
 			}
 ],
@@ -435,11 +410,5 @@ Object -> -> computer "Computer"
 with
 
 	name 'computer',
-	description "This is the boss's computer, this is what you came to take.",
-	before [;
-		take:
-			if(FlagIsClear(F_HAS_COMPUTER)){
-				SetFlag(F_HAS_COMPUTER);
-			}
-	];
+	description "This is the boss's computer, this is what you came to take.";
 

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -195,7 +195,7 @@ u_to Crawl1,
 before [;
 		Go:
 			if(selected_direction==u_to) {
-				if(FlagIsClear(F_HAS_LADDER))
+				if(ladder notin self or player)
 					"You cannot get up there, if only you had a some sort of step stool.";
 			}
 ],
@@ -247,13 +247,7 @@ Object -> -> computer "Computer"
 with
 
 	name 'computer',
-	description "This is April's computer, this is what you came to take.",
-	before [;
-		take:
-			if(FlagIsClear(F_HAS_COMPUTER)){
-				SetFlag(F_HAS_COMPUTER);
-			}
-	];
+	description "This is April's computer, this is what you came to take.";
 
 !=============HALLWAY4(~~~~~~~~~PLACEHOLDER~~~~~~)===================
 Object Hallway4

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -351,7 +351,7 @@ before [;
 				! This should work whether the player is holding the ladder
 				! (it's in the player which is in the SOffice, so transitively
 				! it's in the SOffice), or if the player drops it here.
-				if(ladder notin self)
+				if(ladder notin self or player)
 					"You cannot get up there, if only you had a some sort of step stool.";
 			}
 ],

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -31,9 +31,9 @@ s_to Leave,
 before [;
 	Go:
 		if(selected_direction==s_to) {
-			if(FlagIsClear(F_HAS_COMPUTER))
+			if(computer notin player)
 				"You cannot leave without the boss's computer!";
-				else deadflag = GS_WIN;
+			else deadflag = GS_WIN;
 		}
 	],
 

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -139,7 +139,7 @@ w_to Office7,
 before [;
 		Go:
 			if(selected_direction==w_to) {
-				if(FlagIsClear(F_HAS_BRASSKEY))
+				if(o7key notin player)
 					"The door is locked and likely requires a key.";
 			}
 ],

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -349,8 +349,7 @@ before [;
 		Go:
 			if(selected_direction==u_to) {
 				! This should work whether the player is holding the ladder
-				! (it's in the player which is in the SOffice, so transitively
-				! it's in the SOffice), or if the player drops it here.
+				! or if the player drops it here.
 				if(ladder notin self or player)
 					"You cannot get up there, if only you had a some sort of step stool.";
 			}

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -128,3 +128,34 @@ You cannot leave without the boss's computer!
 > n
 > w
 The door is locked and likely requires a key.
+
+* Try to climb into the crawlspace without the ladder
+> w
+> n
+> n
+> n
+> n
+> u
+You cannot get up there, if only you had a some sort of step stool.
+
+* Use the ladder to climb into the crawlspace
+> e
+> n
+> n
+> w
+> get ladder
+Taken.
+> e
+> n
+> w
+> w
+> n
+> u
+Crawl Space
+You climb up into a small crawl space
+> d
+> drop ladder
+Dropped.
+> u
+Crawl Space
+

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -72,3 +72,7 @@ Hallway7
 > drop key
 > w
 The door is locked and likely requires a key.
+
+* Try to leave without the computer
+> s
+You cannot leave without the boss's computer!

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -76,3 +76,9 @@ The door is locked and likely requires a key.
 * Try to leave without the computer
 > s
 You cannot leave without the boss's computer!
+
+* Try to open the Office7 door without the key
+> w
+> n
+> w
+The door is locked and likely requires a key.


### PR DESCRIPTION
The use of global flags to track game state is a pretty good idea for a first try, but the use of the `in`/`notin` operators may help you do more "active" comparisons of game state when necessary.

I added tests for the two "puzzles" I could reach from the game, but the ladder puzzle up into the crawlspace looked inaccessible with the current map.  I may be wrong, and I see how it's meant to be connected in the design document, but I figured I'd just let you write your own test for that once things got connected up.

The ladder puzzle should also now work if the player drops the ladder in that room, since it only stops you from going up if the ladder isn't in the room rather than in the player.