### PR TITLE
Simple doors

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -1,6 +1,7 @@
 Constant Story "The Office";
 Constant Headline "^It is your first day on the job at Blamazon. You applied here to gain access to their offices after hours to steal the boss's valuable information off of their computer. They have state of the art cyber security preventing any digital leaks of the information so you are here to physically take it.^";
 Constant INITIAL_LOCATION_VALUE = Lobby;
+Constant OPTIONAL_SIMPLE_DOORS;
 
 Include "globals.h";
 Include "ext_cheap_scenery.h";
@@ -119,14 +120,7 @@ with
 
 s_to Waiting,
 n_to Hallway6,
-w_to Office7,
-before [;
-		Go:
-			if(selected_direction==w_to) {
-				if(o7key notin player)
-					"The door is locked and likely requires a key.";
-			}
-],
+w_to Office7Door,
 
 has light;
 
@@ -136,9 +130,17 @@ with
 
 	description "This is an office. To the east there is a door leading back to the hallway.",
 
-e_to Hallway7,
+e_to Office7Door,
 
 has light;
+
+Object -> Office7Door "Office Door"
+with
+	name 'office' 'door',
+	door_dir (e_to) (w_to),
+	found_in Hallway7 Office7,
+	with_key o7key,
+has static door openable ~open lockable locked;
 
 !=============HALLWAY6(~~~~~~~~~~PLACEHOLDER)=======================
 Object Hallway6

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -67,11 +67,19 @@ Dropped.
 > w
 > n
 > w
+You can't, since the Office Door is closed.
+> open door
+It seems to be locked.
+> unlock door with key
+You unlock the Office Door.
+> w
+You can't, since the Office Door is closed.
+> open door
+You open the Office Door.
+> w
+This is an office.
 > e
 Hallway7
-> drop key
-> w
-The door is locked and likely requires a key.
 
 * enter/exit all rooms
 
@@ -114,6 +122,7 @@ The door is locked and likely requires a key.
 > e
 > w
 > s
+> unlock door with key and open door
 > w
 > e
 > s
@@ -123,12 +132,6 @@ The Lobby
 * Try to leave without the computer
 > s
 You cannot leave without the boss's computer!
-
-* Try to open the Office7 door without the key
-> w
-> n
-> w
-The door is locked and likely requires a key.
 
 * Try to climb into the crawlspace without the ladder
 > w

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -160,4 +160,3 @@ You climb up into a small crawl space
 > d
 > use ladder
 Crawl Space
-

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -130,10 +130,12 @@ Hallway7
 The Lobby
 
 * Try to leave without the computer
+
 > s
 You cannot leave without the boss's computer!
 
 * Try to climb into the crawlspace without the ladder
+
 > w
 > n
 > n
@@ -143,6 +145,7 @@ You cannot leave without the boss's computer!
 You cannot get up there, if only you had a some sort of step stool.
 
 * Use the ladder to climb into the crawlspace
+
 > e
 > n
 > n


### PR DESCRIPTION
This is an attempt to fix issue #17, but it is built off of pull request #13, so it's best to merge that first.

I used the "simple doors" mechanism for this, which allows you to create a door object, and set *that* as the destination in your `X_to` direction properties.  I've also made this one locked, and used the `with_key` property to set the brass key as the way to unlock it.

This requires the player to explicitly `unlock door with key`, and then `open door`.  We can make door opening implicit in some cases, but this is the smallest change I could make that kept the functionality the same.

I recommend looking at the `BroomClosetDoor` in [The Job](https://fredrikr.itch.io/the-job) for examples of how to customise the descriptions and other subtle behaviours of such a door.