### PR TITLE
Support more verbs for the ladder puzzle.

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -198,18 +198,24 @@ with
 	description "This room is a small office, there is a wooden desk devoid of any identifying obejcts. One of the ceiling panels seems to me missing in here.",
 
 before [;
-		Use:
-			if(noun==ladder){
-				print "You climb up the ladder. However you had to leave it behind.^";
-				move ladder to self;
+		Use,Climb:
+			if(noun==ladder || 
+					(selected_direction==u_to && ladder in player or self)){
+				print "You climb up the ladder.";
+				if(ladder in player){
+					print "  However you had to leave it behind.^";
+					<Drop ladder>;
+				}
+				print "^";
 				PlayerTo(Crawl1);
 				return true;
 			}
-		Go:
-			if(selected_direction==u_to){
-				print "You cannot get up there, if only you had a some sort of step stool.^";
-				return true;
-			}
+],
+u_to [;
+	if(ladder in player or self){
+		<<Use ladder>>;
+	}
+	"You cannot get up there, if only you had a some sort of step stool.^";
 ],
 s_to Hallway5,
 


### PR DESCRIPTION
I've made the up direction property of the unused office a function.  If the ladder is in the room or held by the player, then the game forces the player to invisibly type `use ladder`.  Otherwise it prints the same failure message that the `before..Go` condition did earlier.

I've also made the use of the ladder force the player to `drop ladder` if they're holding it, before continuing on up to the crawlspace.

In future it may make more sense to put all of this logic into the ladder itself and make it a smart object that becomes a door only when the right conditions are met, but I'll save that possibility for after we've merged in more mundane uses of door objects for issue #17.