### PR TITLE
Try to fix language listings on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.inf linguist-language=inform6


### PR DESCRIPTION
I'm basing this on https://github.com/github/linguist/blob/master/docs/overrides.md and hoping it keeps this project from showing up as 100% `Makefile`...