### PR TITLE
Tidy up output on test suite failures.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ plotex/regtest.py:
 
 # We use z5 for tests because that is what zvm implements.
 %.out: %.test %.z5 plotex/regtest.py node_modules/.bin/zvm 
-	$(TIME) $(PYTHON) plotex/regtest.py -t 5 -i node_modules/.bin/zvm $< > $@ || $(TIME) $(PYTHON) plotex/regtest.py -v -t 5 -i node_modules/.bin/zvm $< | tee $@
+	$(TIME) $(PYTHON) plotex/regtest.py -v -t 5 -i node_modules/.bin/zvm $< > $@ || ! grep -Hn '^\*\*\*' $@
 
 %.z3: %.inf ${LIB} ${INFORM}
 	${INFORM} -e -E1 -d2 -s +include_path=./inform6unix/punyinform/lib/ -v3 $<


### PR DESCRIPTION
This now only prints the lines describing a failure, in a format that many editors will use to take you right to the output file at that line. This means that when I type `:make` in vim/neovim, an error will jump me right to the `foo.out` test suite output at the location of the first failure condition.  It even lets me iterate through the list of them.

I also cut out an extra run of the tests, so that failures shouldn't take longer to run through.

Tested with busybox grep, so this works on pure POSIX.