### PR TITLE
Add some help text commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OUT=$(patsubst %.test,%.out,$(TEST))
 
 # We use wildcards to catch whatever the current version is.
 INFORM:=inform6unix/inform-6.*
-LIB=inform6unix/punyinform/lib/*.h
+LIB=inform6unix/punyinform/lib/*.h *.h
 PYTHON:=$(shell which python3)
 ifdef PYTHON
 # We're all right here
@@ -53,13 +53,13 @@ plotex/regtest.py:
 	$(TIME) $(PYTHON) plotex/regtest.py -v -t 5 -i node_modules/.bin/zvm $< > $@ || ! grep -Hn '^\*\*\*' $@
 
 %.z3: %.inf ${LIB} ${INFORM}
-	${INFORM} -e -E1 -d2 -s +include_path=./inform6unix/punyinform/lib/ -v3 $<
+	${INFORM} -e -E1 -d2 -s +include_path=./inform6unix/punyinform/lib/,./ -v3 $<
 
 %.z5: %.inf ${LIB} ${INFORM}
-	${INFORM} -e -E1 -d2 -s +include_path=./inform6unix/punyinform/lib/ -v5 $<
+	${INFORM} -e -E1 -d2 -s +include_path=./inform6unix/punyinform/lib/,./ -v5 $<
 
 %.z8: %.inf ${LIB} ${INFORM}
-	${INFORM} -e -E1 -d2 -s +include_path=./inform6unix/punyinform/lib/ -v8 $<
+	${INFORM} -e -E1 -d2 -s +include_path=./inform6unix/punyinform/lib/,./ -v8 $<
 
 clean:
 	rm -f *.z? *.out

--- a/help.h
+++ b/help.h
@@ -1,10 +1,13 @@
-! vim: set filetype=inform
-! This provides a series of explanatory texts for new users unfamiliar with IF.
+! This library provides a series of explanatory texts
+! for new users unfamiliar with IF.
 
-! helper function for formatting
+Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
+
+
+! helper functions for formatting
 [ bf text; style bold; print (string) text; style roman; ];
 [ nm text; style bold; print (name) text; style roman; ];
-[ ul text; style underline; print (string) text; style roman; ];
+[ ul text; font off; style underline; print (string) text; style roman; font on; ];
 [ rv text; style reverse; print (string) text; style roman; ];
 
 [ IntroSub;
@@ -27,7 +30,9 @@
 		", ", (ul) "north", ", or even just ", (ul) "n", ".
 		Most locations represent entire rooms,
 		but areas like hallways
-		may be broken up.",
+		may be broken up.
+		It helps a lot to draw a map
+		while you play!",
 		"^ You will find various objects
 		located throughout the game.
 		You may pick many of them up
@@ -49,10 +54,127 @@
 ];
 
 [ HelpSub;
-	print "XXX: FIXME TO BE WRITTEN";
+	print (bf) "How To Play This Game^",
+		"^ This game was built with PunyInform,
+		which is a system designed to recreate
+		the ~Interactive Fiction~ games of Infocom.
+		These games use a simple parser
+		to split your typed instructions
+		into verbs,
+		prepositions,
+		and objects.
+		^ You will need to enter instructions
+		beginning with imperative verbs,
+		as though you were giving orders 
+		to the character you are playing in the game.
+		As examples,
+		let's begin with movement verbs:^",
+		"^    ", (ul) "north", "/", (ul) "n",
+		" ", (ul) "south", "/", (ul) "s",
+		" ", (ul) "east", "/", (ul) "e",
+		" ", (ul) "west", "/", (ul) "w",
+		" ", (ul) "up", "/", (ul) "u",
+		" ", (ul) "down", "/", (ul) "d",
+		"^^ These are all shortcuts
+		for the verb ", (ul) "go", ".
+		So typing ", (ul) "s", " or ", (ul) "south", 
+		" is the same as entering ", (ul) "go south",
+		".  Here are some other verbs:^",
+		"^    ", (ul) "look", "/", (ul) "l",
+		" -- Display the description of your character's current location, and list any obvious items there.",
+		"^    ", (ul) "inventory", "/", (ul) "i",
+		" -- List all of the objects your character is carrying.",
+		"^    ", (ul) "again", "/", (ul) "g",
+		" -- Repeat the last instruction.",
+		"^    ", (ul) "quit", "/", (ul) "q",
+		" -- Quit the game (you'll be asked for confirmation).",
+		"^    ", (ul) "restart", 
+		" -- Start the game over from the beginning.",
+		"^    ", (ul) "undo", 
+		" -- Undo the last instruction.",
+		"^^ Most verbs accept nouns
+		as objects of their actions.
+		Here are some useful verbs
+		that act on direct objects:^",
+		"^    ", (ul) "get", "/", (ul) "take", "/", (ul) "pick up", (bf) " object",
+		" -- Pick up an object so that your character carries it around.",
+		"^    ", (ul) "drop", "/", (ul) "discard", (bf) " held object",
+		" -- Leave an object in your character's current location.",
+		"^    ", (ul) "look at", "/", (ul) "examine", "/", (ul) "x", (bf) " object",
+		" -- Display the description of the object you specify, if it's visible.",
+		"^    ", (ul) "open", "/", (ul) "uncover", "/", (ul) "unwrap", (bf) " object",
+		" -- Open a thing that can be opened or closed, such as a door or a box.",
+		"^    ", (ul) "close", "/", (ul) "cover", "/", (ul) "shut", (bf) " object",
+		" -- Close something that is open.",
+		"^    ", (ul) "climb", "/", (ul) "scale", (bf) " object",
+		" -- Climb up an object to reach somewhere else.",
+		"^^ Some instructions require you to specify
+		an indirect object,
+		which is used to complete the action:^",
+		"^    ", (ul) "say", "/", (ul) "answer", "/", (ul) "shout", (bf) " topic ", (ul) "to", (bf) " listener",
+		" -- Say something to a listening object or character in the game.",
+		"^    ", (ul) "unlock", "/", (ul) "pry", "/", (ul) "force open", (bf) " object ", (ul) "with", (bf) " held object",
+		" -- Change a stuck or locked object, so that you can ", (ul) "open", " it.",
+		"^    ", (ul) "hit", "/", (ul) "smash", "/", (ul) "break", (bf) " object ", (ul) "with", (bf) " held object",
+		" -- Apply force to one object with another.",
+		"^^ Note that some verbs
+		do very different things
+		depending on the rest of the sentence:^",
+		"^    ", (ul) "throw", (bf) " held object",
+		" -- The same as ", (ul) "drop", ".",
+		"^    ", (ul) "throw", "/", (ul) "put", (bf) " held object ", (ul) "in", (bf) " container", ".",
+		" -- Put an object inside another.",
+		"^    ", (ul) "throw", (bf) " held object ", (ul) "at", (bf) " container", ".",
+		" -- Throw one object at another.";
+
+
+
+		new_line;
 ];
+
+Array dont_panic static --> 1 12 "Don't Panic!";
+[ StuckSub;
+	! This will cut off scrollback in parchment,
+	! but it's good for this moment.
+	QuoteBox(dont_panic);
+
+	print (bf) "^^Feeling A Bit Stuck?^",
+		"^Games like these are made of puzzles,
+		and the solutions do not always
+		immediately present themselves.
+		Here are some tips to help you through.",
+		(bf) "^^Draw A Map^",
+		"^Draw boxes for each location in the game,
+		and connect them with lines
+		based on the compass directions.
+		Note the location
+		of locked doors,
+		useful items,
+		and other notable features of the rooms.
+		This will help you get some perspective,
+		and possibly keep you
+		from getting lost.",
+		(bf) "^^Refer To Course Materials^",
+		"^This game is an illustration
+		of real-world problems
+		in physical security.
+		You will not always be able
+		to gain access to something
+		via the ~front door~,
+		so try to think of other ways
+		to get what you want.^";
+];
+
 
 Verb 'intro' * -> Intro;
 Verb 'help' * -> Help;
-Verb 'stuck' * -> Strong; ! We use the StrongSub so we print advice if the player starts swearing, instead of scolding them for their language.
-
+Verb 'stuck'
+	* -> Stuck
+	* topic -> Stuck;
+! We hijack `Strong` to give some helpful advice
+! when the player starts swearing at the game.
+! This will catch all the synonyms
+! from PunyInform's `grammar.h`.
+Extend 'damn' replace
+	* -> Stuck
+	* topic -> Stuck;

--- a/help.h
+++ b/help.h
@@ -135,7 +135,7 @@ Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
 		new_line;
 ];
 
-Array dont_panic static --> 1 12 "Don't Panic!";
+Array dont_panic --> 1 13 "Don't Panic!";
 [ StuckSub;
 	! This will cut off scrollback in parchment,
 	! but it's good for this moment.

--- a/help.h
+++ b/help.h
@@ -150,7 +150,7 @@ Array dont_panic --> 1 13 "Don't Panic!";
 		"^Draw boxes for each location in the game,
 		and connect them with lines
 		based on the compass directions.
-		Note the location
+		Mark the location
 		of locked doors,
 		useful items,
 		and other notable features of the rooms.

--- a/help.h
+++ b/help.h
@@ -78,7 +78,7 @@ Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
 		" ", (ul) "west", "/", (ul) "w",
 		" ", (ul) "up", "/", (ul) "u",
 		" ", (ul) "down", "/", (ul) "d",
-		"^^ These are all shortcuts
+		"^^These are all shortcuts
 		for the verb ", (ul) "go", ".
 		So typing ", (ul) "s", " or ", (ul) "south", 
 		" is the same as entering ", (ul) "go south",
@@ -95,7 +95,7 @@ Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
 		" -- Start the game over from the beginning.",
 		"^    ", (ul) "undo", 
 		" -- Undo the last instruction.",
-		"^^ Most verbs accept nouns
+		"^^Most verbs accept nouns
 		as objects of their actions.
 		Here are some useful verbs
 		that act on direct objects:^",
@@ -111,7 +111,7 @@ Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
 		" -- Close something that is open.",
 		"^    ", (ul) "climb", "/", (ul) "scale", (bf) " object",
 		" -- Climb up an object to reach somewhere else.",
-		"^^ Some instructions require you to specify
+		"^^Some instructions require you to specify
 		an indirect object,
 		which is used to complete the action:^",
 		"^    ", (ul) "say", "/", (ul) "answer", "/", (ul) "shout", (bf) " topic ", (ul) "to", (bf) " listener",
@@ -120,7 +120,7 @@ Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
 		" -- Change a stuck or locked object, so that you can ", (ul) "open", " it.",
 		"^    ", (ul) "hit", "/", (ul) "smash", "/", (ul) "break", (bf) " object ", (ul) "with", (bf) " held object",
 		" -- Apply force to one object with another.",
-		"^^ Note that some verbs
+		"^^Note that some verbs
 		do very different things
 		depending on the rest of the sentence:^",
 		"^    ", (ul) "throw", (bf) " held object",

--- a/help.h
+++ b/help.h
@@ -166,7 +166,7 @@ Array dont_panic static --> 1 12 "Don't Panic!";
 ];
 
 
-Verb 'intro' * -> Intro;
+Verb 'intro' 'info' * -> Intro;
 Verb 'help' * -> Help;
 Verb 'stuck'
 	* -> Stuck

--- a/help.h
+++ b/help.h
@@ -1,0 +1,58 @@
+! vim: set filetype=inform
+! This provides a series of explanatory texts for new users unfamiliar with IF.
+
+! helper function for formatting
+[ bf text; style bold; print (string) text; style roman; ];
+[ nm text; style bold; print (name) text; style roman; ];
+[ ul text; style underline; print (string) text; style roman; ];
+[ rv text; style reverse; print (string) text; style roman; ];
+
+[ IntroSub;
+	print (bf) "Introduction^",
+		"^The game you are now playing
+		is a kind of command-line story.
+		You control your character
+		by typing commands
+		at the ", (bf) "> ", "prompt.",
+		"^ If your commands are successful,
+		the game will describe what happens.
+		So if your command is ", (ul) "look", ",
+		then you will see a description of your surroundings.
+		If you scroll back a bit right now,
+		you should see a description of: ",
+		(nm) location, ".",
+		"^ Your character will move
+		from location to location
+		as you type commands such as ", (ul) "go north",
+		", ", (ul) "north", ", or even just ", (ul) "n", ".
+		Most locations represent entire rooms,
+		but areas like hallways
+		may be broken up.",
+		"^ You will find various objects
+		located throughout the game.
+		You may pick many of them up
+		with commands such as ",
+		(ul) "take sonic screwdriver", 
+		" or ", (ul) "get retroencabulator", ".
+		You can set them down again
+		by typing a command like ", (ul) "drop teddy bear", ".
+		Some of these objects are useful tools,
+		and may help you use commands like ",
+		(ul) "pry safe with crowbar", ".",
+		"^ You may notice your ", (rv) "Score:", " going up
+		as you obtain certain items
+		or gain access to some areas.
+		That's generally a sign
+		that you're on the right path!",
+		"^^For more detailed advice on play,
+		type ", (ul) "help", " or ", (ul) "stuck", ".";
+];
+
+[ HelpSub;
+	print "XXX: FIXME TO BE WRITTEN";
+];
+
+Verb 'intro' * -> Intro;
+Verb 'help' * -> Help;
+Verb 'stuck' * -> Strong; ! We use the StrongSub so we print advice if the player starts swearing, instead of scolding them for their language.
+

--- a/help.h
+++ b/help.h
@@ -20,14 +20,14 @@ Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
 		You control your character
 		by typing commands
 		at the ", (bf) "> ", "prompt.",
-		"^ If your commands are successful,
+		"^^If your commands are successful,
 		the game will describe what happens.
 		So if your command is ", (ul) "look", ",
 		then you will see a description of your surroundings.
 		If you scroll back a bit right now,
 		you should see a description of: ",
 		(nm) location, ".",
-		"^ Your character will move
+		"^^Your character will move
 		from location to location
 		as you type commands such as ", (ul) "go north",
 		", ", (ul) "north", ", or even just ", (ul) "n", ".
@@ -36,7 +36,7 @@ Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
 		may be broken up.
 		It helps a lot to draw a map
 		while you play!",
-		"^ You will find various objects
+		"^^You will find various objects
 		located throughout the game.
 		You may pick many of them up
 		with commands such as ",
@@ -47,7 +47,7 @@ Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
 		Some of these objects are useful tools,
 		and may help you use commands like ",
 		(ul) "pry safe with crowbar", ".",
-		"^ You may notice your ", (rv) "Score:", " going up
+		"^^You may notice your ", (rv) "Score:", " going up
 		as you obtain certain items
 		or gain access to some areas.
 		That's generally a sign
@@ -58,7 +58,7 @@ Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
 
 [ HelpSub;
 	print (bf) "How To Play This Game^",
-		"^ This game was built with PunyInform,
+		"^^This game was built with PunyInform,
 		which is a system designed to recreate
 		the ~Interactive Fiction~ games of Infocom.
 		These games use a simple parser
@@ -66,7 +66,7 @@ Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
 		into verbs,
 		prepositions,
 		and objects.
-		^ You will need to enter instructions
+		^^You will need to enter instructions
 		beginning with imperative verbs,
 		as though you were giving orders 
 		to the character you are playing in the game.

--- a/help.h
+++ b/help.h
@@ -146,6 +146,12 @@ Array dont_panic --> 1 13 "Don't Panic!";
 		and the solutions do not always
 		immediately present themselves.
 		Here are some tips to help you through.",
+		(bf) "^^Read The Freindly Manual^",
+		"^The ", (ul) "intro", " command
+		will help you get started,
+		and the ", (ul) "help", " command
+		provides a more detailed manual
+		with example verbs to try.",
 		(bf) "^^Draw A Map^",
 		"^Draw boxes for each location in the game,
 		and connect them with lines

--- a/help.h
+++ b/help.h
@@ -10,6 +10,9 @@ Include "ext_quote_box.h"; ! Used in the `Stuck` routine.
 [ ul text; font off; style underline; print (string) text; style roman; font on; ];
 [ rv text; style reverse; print (string) text; style roman; ];
 
+! Note that this is written
+! using "semantic linefeeds":
+! https://rhodesmill.org/brandon/2012/one-sentence-per-line/
 [ IntroSub;
 	print (bf) "Introduction^",
 		"^The game you are now playing

--- a/retro.css
+++ b/retro.css
@@ -60,8 +60,9 @@ div#gameport {
     text-shadow: 0 0 4px var(--amber);
 }
 
-.Input, .Style_input {
+.Input, .Style_input, .Style_emphasized {
     text-decoration: underline;
+    font-style: normal !important;
     color: var(--amber);
     text-shadow: 0 0 2px var(--amber);
 }

--- a/retro.css
+++ b/retro.css
@@ -60,7 +60,7 @@ div#gameport {
     text-shadow: 0 0 4px var(--amber);
 }
 
-.Input, .Style_input, .Style_emphasized {
+.Input, .Style_input, .Style_emphasized, .Style_user2 {
     text-decoration: underline;
     font-style: normal !important;
     color: var(--amber);

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -1,5 +1,5 @@
 Constant Story "The Office";
-Constant Headline "^It is your first day on the job at Blamazon. You applied here to gain access to their offices after hours to steal the boss's valuable information off of their computer. They have state of the art cyber security preventing any digital leaks of the information so you are here to physically take it.^";
+Constant Headline "^^You step through the front doors of the office of Blamazon. It is pitch black outside. You are here after hours.^^This is a work of ~interactive fiction~.  If this is your first time playing such a game, please type INTRO at the prompt below.^^";
 Constant INITIAL_LOCATION_VALUE = Lobby;
 Constant OPTIONAL_SIMPLE_DOORS;
 Constant OPTIONAL_EXTENDED_VERBSET;
@@ -40,7 +40,7 @@ Verb 'jimmy'
 	* noun 'with' noun -> Jimmy;
 
 [Initialise;
-  "You step through the front doors of the office of Blamazon. It is pitch black outside. You are here after hours.";
+  "It is your first day on the job at Blamazon. You applied here to gain access to their offices after hours to steal the boss's valuable information off of their computer. They have state of the art cyber security preventing any digital leaks of the information so you are here to physically take it.";
 ];
 
 !===================LOBBY=======================

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -3,6 +3,7 @@ Constant Headline "^It is your first day on the job at Blamazon. You applied her
 Constant INITIAL_LOCATION_VALUE = Lobby;
 Constant OPTIONAL_SIMPLE_DOORS;
 Constant OPTIONAL_EXTENDED_VERBSET;
+Constant OPTIONAL_PROVIDE_UNDO;
 Constant DEBUG;
 
 Constant voxfail = "The tower silently listens to your voice, but then flashes red and buzzes disapprovingly.";

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -11,6 +11,7 @@ Constant handfail = "You place your hand on the handprint recognizer. Light scan
 Include "globals.h";
 Include "ext_cheap_scenery.h";
 Include "puny.h";
+Include "help.h";
 
 attribute heavy;
 


### PR DESCRIPTION
I took a look at the Emily Short and Fredrik Ramsberg help modules for inform6, and they all tend to be *incredibly wordy*.  My goal is to have an `intro` command that gives a 1-2 page quick intro, a `help` command that lists verbs along with allowed prepositions, and then a `stuck` verb that you can hook onto the `StrongSub` so that a player might get it by surprise when swearing into the parser.

I think `stuck` is more about the game itself, and may have some pedagogical constraints, but I'm happy to take a stab at an initial version.