### PR TITLE
Make the game `VERBOSE` by default.

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -40,6 +40,9 @@ Verb 'jimmy'
 	* noun 'with' noun -> Jimmy;
 
 [Initialise;
+  ! Start out VERBOSE instead of BRIEF
+  lookmode = 2;
+
   "It is your first day on the job at Blamazon. You applied here to gain access to their offices after hours to steal the boss's valuable information off of their computer. They have state of the art cyber security preventing any digital leaks of the information so you are here to physically take it.";
 ];
 


### PR DESCRIPTION
It seems that Inform 7 has moved on from the brief descriptions on already-visited rooms, and this was probably a UX concern largely focused on limitations of 8-bit computers.  Since PunyInform is aimed at those platforms, it kept the old default.

So we just set it in Initialise and move on, I think.