### PR TITLE
Don't say "a Ellie's Hard Drive".  Fixes #73

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -728,10 +728,11 @@ with
 
 has static openable lockable locked container;
 
-Object -> -> hardDrive "Ellie's Hard Drive"
+Object -> -> hardDrive "Ellie's hard drive"
 with
 	name 'HDD' 'hard' 'disk' 'drive',
-	description "This is a Hard Disk Drive from Ellie's computer, if you take this, you're sure you can get the information on it at a later time.";
+	description "This is a hard disk drive from Ellie's computer, if you take this, you're sure you can get the information on it at a later time."
+has proper;
 
 Object -> Office1Door "Office Door"
 with

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -307,5 +307,7 @@ shatter
 > jimmy door with card
 > e 
 > open case with screwdriver
+> l
+which contains Ellie's hard drive
 > take hard drive
 Taken.


### PR DESCRIPTION
I also de-capitalised "hard drive" to make it more natural in printed text.