### PR TITLE
`pick lock` and refactor incl. tests.  Fixes: #71

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -43,6 +43,11 @@ Verb 'jimmy' 'lift'
 	* 'apart'/'open' noun 'with' held           -> Unlock
 	* noun 'apart'/'open' 'with' held           -> Unlock;
 
+Extend 'pick' first
+	* noun 'with' held                          -> Unlock
+	* 'apart'/'open' noun 'with' held           -> Unlock
+	* noun 'apart'/'open' 'with' held           -> Unlock;
+
 ! 'screw' and 'unscrew' are defined as synonyms for 'turn',
 ! rather unhelpfully for a game that wishes to distinguish them.
 ! We keep that behaviour, and extend here.
@@ -52,6 +57,9 @@ Extend only 'unscrew' first
 
 Extend only 'screw' first
 	* noun 'with' held                          -> Lock;
+
+Extend only 'turn' first
+	* noun 'with' held                          -> Turn;
 
 [Initialise;
   ! Start out VERBOSE instead of BRIEF
@@ -698,26 +706,8 @@ cheap_scenery
 w_to Office1Door,
 Before[;
 	Use:
-		if(noun==ellieComputer){
-			print "You attempt to use the computer, however, you are immediately challenged by a log in screen requesting a password. It seems the information on the hard drive of this
-			       computer will have to be accessed some other way.^";
-			return true;
-		}
-
-		if(noun==screwdriver && second==ellieComputer){
-			print "You unscrew the back panel of the computer exposing the inside of it!^";
-			give ellieComputer ~locked;
-			give ellieComputer open;
-			return true;
-		}
-	Unlock:
-		if(noun==ellieComputer && second==screwdriver){
-			print "You unscrew the 4 screws at the back of the computer opening the case!^";
-			give ellieComputer ~locked;
-			give ellieComputer open;
-			return true;
-		}
-
+		if(noun==screwdriver && second==ellieComputer)
+			<<Unlock computer>>;
 ],
 
 has light;
@@ -731,10 +721,29 @@ has static supporter;
 
 Object -> ellieComputer "Computer"
 with
-	name 'computer' 'case',
-	description "This computer is bolted down to the floor as to prevent it from being moved. On the back there are a number of wires exiting the computer. On the side there are 4 screws holding the
-		     side panel on.",
+	name 'computer' 'case' 'screws',
+	description "This computer is bolted down to the floor as to prevent it from being moved. On the back there are a number of wires exiting the computer. On the side there are 4 screws holding the side panel on.",
 	with_key screwdriver,
+	before [;
+		Use:
+			"You attempt to use the computer, however, you are immediately challenged by a log in screen requesting a password. It seems the information on the hard drive of this computer will have to be accessed some other way.^";
+		Turn:
+			if(self has locked) {
+				<<Unlock self second>>;
+			} else {
+				<close self>;
+				<<Lock self second>>;
+			}
+		Lock:
+			<close self>;
+	],
+	after [;
+		Unlock:
+			print "You unscrew the 4 screws at the back of the computer, opening the case!^";
+			give self open;
+		Lock:
+			"You tighten the 4 screws at the back of the computer, sealing it shut.";
+	],
 
 has static openable lockable locked container;
 
@@ -746,7 +755,7 @@ has proper;
 
 Object -> Office1Door "Office Door"
 with
-	name 'office' 'door',
+	name 'office' 'door' 'lock',
 	description "This is an old wood antique door. You can see it has an incredibly simple locking mechanism, it could easy unlocked if you had a thin stiff object to jimmy the lock.",
 	door_dir (e_to) (w_to),
 	found_in Hallway1 Office1,

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -289,24 +289,49 @@ Taken.
 > break wall with plant
 shatter
 
-* test screwdriver and coffee card puzzle
+* _ready coffee card
 > w
 > n
 > n
 > e
 > take screwdriver
+Taken.
 > w
 > n
 > e
 > s
 > take card
+Taken.
 > n
 > e
 > s
 > s
+
+* jimmy to get hard drive
+>{include} _ready coffee card
 > jimmy door with card
 > e 
 > unscrew case with screwdriver
+> l
+which contains Ellie's hard drive
+> take hard drive
+Taken.
+
+* pick to get hard drive
+>{include} _ready coffee card
+> pick lock with card
+> e 
+> unscrew screws with screwdriver
+> l
+which contains Ellie's hard drive
+> take hard drive
+Taken.
+
+* turn screws to get hard drive
+>{include} _ready coffee card
+> unlock door with card
+> e 
+> turn screws with screwdriver
 > l
 which contains Ellie's hard drive
 > take hard drive


### PR DESCRIPTION
This is a slightly more invasive change than I planned, partly because I moved some logic out of the room that was reacting to certain actions, and put it in the relevant objects that are acted upon.  I feel like this is more of a "carving with the grain" approach to these things, in most cases.

I also made use of the `>{include} ` feature of `regtest.py` to let me test multiple situations outside the door that we can't lock after we've unlocked it.  We may want to simplify our tests by taking the mess of "pick up a bunch of stuff and get to this room" blocks into their own non-running tests (the leading underscore or hyphen in the name ensures this), and then include them in each actual test from then on.  We should have a tree of paths that we can extend as we go.

Finally, we had a chat about the future of the `Use` verb, and how I think it may have a more sustainable future as a more context-aware help system.  This is the set of changes that inspired me to start thinking through that process somewhat.