### PR TITLE
desk hasnt concealed so we see the key. Fixes #79

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -98,7 +98,7 @@ has light;
 Object Receptionist "Receptionist's Area"
 with
 
-	description "This area is a small cubical where the receptionist works. There is a desk here. To the south there is the lobby.",
+	description "This area is a small cubicle where the receptionist works. The visitors' space in the lobby is to the south.",
 
 s_to Lobby,
 
@@ -115,7 +115,7 @@ with
 			"A single closed drawer is the only thing spoiling its stylish lines.";
 		}
 	],
-has static concealed container openable;
+has static container openable;
 
 Object -> -> o7key "loose brass key"
 with

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -57,6 +57,8 @@ The Lobby
 > get key
 You can't see any such thing.
 > open desk
+> look
+You can see a Receptionist's Desk (which contains a loose brass key) here.
 > get key
 Taken.
 > drop key


### PR DESCRIPTION
Originally I solved the problem by making the desk concealed (since it's described in the room description) but given #79 this makes more sense to just let it be printed by the normal object listing processes and remove it from the room description.