### PR TITLE
New default locked message in Puny 4.4

### DIFF
--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -75,7 +75,7 @@ Dropped.
 > w
 You can't, since the Office Door is closed.
 > open door
-It seems to be locked.
+It's locked.
 > unlock door with key
 You unlock the office door and open it!
 > w


### PR DESCRIPTION
Puny has been shortening messages to cut down on bytes, it seems.  When it used to say "It seems to be locked." by default, it now says "It's locked."

If you're trying a `make dep`, you may hit a git conflict.  Just `rm -rf inform6unix;make` and you'll have the latest puny bundle.