### PR TITLE
fix #150

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -988,7 +988,7 @@ has scored;
 
 Object -> flashlight "flashlight"
 with
-	name 'flashlight' 'torch' 'flash' 'light' 'lamp',
+	name 'flashlight' 'torch' 'flash' 'light',
 	description [;
 		print "This cheap flashlight has a Tastytronic Industries logo emblazoned on it.  It is currently ";
 		if (self has on) "on.";


### PR DESCRIPTION
flashlight had 'lamp' as an alias, which meant if you were holding the flashlight the lamp in the waiting room was incredibly hard to interact with as the lamp's other aliases are obscure.