### PR TITLE
Fix to Issue #258

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -217,6 +217,8 @@ with
 	before [;
 		Go:
 			if(selected_direction==n_to && elevatorDoor has open){
+				remove securityCard;
+
 				PlayerTo(Lobby,2);
 				print "^You recall from your interview that the first office on the west side requires a brass key to open. To start maybe look for that key, or tackle any office you like first!";
 				return 1;
@@ -244,14 +246,15 @@ has static door ~open locked concealed;
 
 Object securityCard "Security Key Fob"
 with 
-	name 'security' 'fob' 'id' 'identification' 'pass',
+	name 'security' 'fob' 'id' 'identification' 'pass' 'key',
 	description [;
 		print "This is a small plastic key fob with a fake name you gave them during the hiring process. ";
 		if(player in Tutorial){
 			print "Good job! You probably noticed in your inventory as well a Task List. You may look, or examine this to see the progress you have made. It shows you all items you need to recover, and if the item is in your inventory or not.";
 		}
 	],
-has heavy;
+	found_in Tutorial,
+has concealed heavy;
 
 !===================LOBBY=======================
 Object Lobby "The Lobby"

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -254,7 +254,7 @@ with
 		}
 	],
 	found_in Tutorial,
-has concealed heavy;
+has heavy;
 
 !===================LOBBY=======================
 Object Lobby "The Lobby"

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -37,6 +37,33 @@
 # > l
 # It feels so nice, standing in the box.
 
+* leave tutorial and remove fob from player
+
+> insert key into scanner
+> take key
+> insert fob into scanner
+> n
+> i
+!Security Key Fob
+
+* make sure game doesn't mistake receptionist's key for the fob
+
+> insert key into scanner
+> take key
+> insert fob into scanner
+> n
+> n
+> get key
+You can't see any such thing.
+> open drawer
+You open the Receptionist's Desk, revealing a loose brass key.
+> look
+You can see a Receptionist's Desk (which contains a loose brass key) here.
+> get key
+Taken.
+> drop key
+Dropped.
+
 * loop the hallway
 
 > insert fob into scanner
@@ -135,6 +162,12 @@ score has just gone up by
 > x list
 [X] Printed
 
+* test 'key' noun for scanner
+> insert key into scanner
+Oops, you fumble the fob and drop it on the floor of the elevator!
+> take key
+Taken.
+> insert key into scanner
 
 * enter/exit all rooms
 


### PR DESCRIPTION
* Added 'key' to the list of names for securityCard (fob);
* Added line of code to remove the securityCard (fob) from the player's inventory upon entering the lobby for the first time (since it is not used thereafter)

Added two tests, which:
(1) Ensure that the Security Key Card is no longer in the player's inventory upon entering the Lobby, and 
(2) Ensure the player is able to pick up the receptionist's key, without confusing the parser.