### PR TITLE
Fix to Issue #258

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -244,7 +244,7 @@ has static door ~open locked concealed;
 
 Object securityCard "Security Key Fob"
 with 
-	name 'security' 'fob' 'id' 'identification' 'pass',
+	name 'security' 'fob' 'id' 'identification' 'pass' 'key',
 	description [;
 		print "This is a small plastic key fob with a fake name you gave them during the hiring process. ";
 		if(player in Tutorial){

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -64,7 +64,7 @@ The Lobby
 > n
 > n
 > get key
-You can't see any such thing.
+You already have it.
 > open drawer
 You open the Receptionist's Desk, revealing a loose brass key.
 > look
@@ -72,7 +72,16 @@ You can see a Receptionist's Desk (which contains a loose brass key) here.
 > get key
 Taken.
 > drop key
+Do you mean the loose brass key or the Security Key Fob?
+> brass key
 Dropped.
+> get key
+Taken.
+> drop key
+Do you mean the loose brass key or the Security Key Fob?
+> loose brass key
+Dropped.
+
 
 * _get into o7
 

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -81,6 +81,10 @@ Taken.
 Do you mean the loose brass key or the Security Key Fob?
 > loose brass key
 Dropped.
+> get key
+Taken.
+> drop brass key
+Dropped.
 
 
 * _get into o7
@@ -100,6 +104,8 @@ You can't, since the Brass Knobbed Door is closed.
 > open door
 /It.* locked.
 > unlock door with key
+Do you mean the loose brass key or the Security Key Fob?
+> brass key
 You unlock the Brass Knobbed door and open it!
 > w
 This is a researcher's office
@@ -112,6 +118,8 @@ Hallway
 > close door
 You close the Brass Knobbed Door.
 > lock door with key
+Do you mean the loose brass key or the Security Key Fob?
+> brass key
 You carefully close and lock the office door with the brass key.
 
 * test terminal input
@@ -189,7 +197,7 @@ score has just gone up by
 > e
 > w
 > s
-> unlock door with key and open door
+> unlock door with brass key and open door
 > w
 > e
 > s
@@ -530,7 +538,7 @@ Taken.
 > take chair
 Taken.
 > n
-> unlock door with key
+> unlock door with brass key
 You unlock
 > w
 Research Office


### PR DESCRIPTION
* Added 'key' to list of synonyms for securityCard (fob)
* Changed tests that refer to loose brass key by "key" to test the parser