### PR TITLE
Fixes #262: Use flathead to unlock ellies computer

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -1351,8 +1351,8 @@ with
 	instructions "You attempt to use the computer, however, you are immediately challenged by a log in screen requesting a password.^^It seems the information on the hard drive of this computer will have to be accessed some other way.",
 	before [;
 		Turn:
-			if (second==screwdriver){
-				print "You unscrew the screws with your phillips head screwdriver! You can now see inside!";
+			if (second==screwdriver || second==flathead){
+				print "You unscrew the screws with your screwdriver! You can now see inside!";
 				give ellieComputer ~locked;
 				give ellieComputer open;
 				return true;
@@ -1362,8 +1362,8 @@ with
 				return true;
 			}
 		Unlock:
-			if (second==screwdriver){
-				print "You unscrew the screws with your phillips head screwdriver! You can now see inside!";
+			if (second==screwdriver || second==flathead){
+				print "You unscrew the screws with your screwdriver! You can now see inside!";
 				give ellieComputer ~locked;
 				give ellieComputer open;
 				return true;

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -457,28 +457,61 @@ Taken.
 > s
 > s
 
-* jimmy to get hard drive
+* jimmy to get into ellie's office
+
 >{include} _ready coffee card
 > jimmy door with coffee card
 > e 
 Ellie's Office
-> unscrew case with screwdriver
-Do you mean the Flathead or the Phillips Head Screwdriver?
-> flathead
+
+* pick to get into ellie's office
+
+>{include} _ready coffee card
+> pick lock with coffee card
+> e 
+Ellie's Office
+
+
+* _get into ellies office
+>{include} _ready coffee card
+> jimmy door with coffee card
+> e
+Ellie's Office
+
+* turn screws using flathead to get hard drive
+
+>{include} _get into ellies office
+> turn screws with flathead
 > l
 which contains Ellie's hard drive
 > take hard drive
 Taken.
 
-* pick to get hard drive
->{include} _ready coffee card
-> pick lock with coffee card
-> e 
-> unscrew screws with phillips head screwdriver
+* turn screws using screwdriver to get hard drive
+
+>{include} _get into ellies office
+> turn screws with phillips head screwdriver
 > l
 which contains Ellie's hard drive
 > take hard drive
 Taken.
+
+* unscrew case using flathead to get hard drive
+>{include} _get into ellies office
+> unscrew case with flathead
+> l
+which contains Ellie's hard drive
+> take hard drive
+Taken.
+
+* unscrew case using phillips head to get hard drive
+>{include} _get into ellies office
+> unscrew case with phillips head screwdriver
+> l
+which contains Ellie's hard drive
+> take hard drive
+Taken.
+
 
 * turn screws to get hard drive
 >{include} _ready coffee card

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -441,8 +441,14 @@ shatter
 Taken.
 > w
 > n
+> n
+> take tarp
+> take flathead
+Taken.
+> s
 > e
 > s
+(Kitchenette)
 > open cabinet
 > take card
 Taken.
@@ -455,7 +461,10 @@ Taken.
 >{include} _ready coffee card
 > jimmy door with coffee card
 > e 
+Ellie's Office
 > unscrew case with screwdriver
+Do you mean the Flathead or the Phillips Head Screwdriver?
+> flathead
 > l
 which contains Ellie's hard drive
 > take hard drive
@@ -465,7 +474,7 @@ Taken.
 >{include} _ready coffee card
 > pick lock with coffee card
 > e 
-> unscrew screws with screwdriver
+> unscrew screws with phillips head screwdriver
 > l
 which contains Ellie's hard drive
 > take hard drive
@@ -482,7 +491,7 @@ You unlock the office door and open it!
 > jimmy door with coffee card
 You unlock the office door and open it!
 > e 
-> turn screws with screwdriver
+> turn screws with flathead
 > l
 which contains Ellie's hard drive
 > take hard drive


### PR DESCRIPTION
* Added ability for player to use either flathead screwdriver OR phillips head screwdriver to unlock Ellie's computer case. (Entering "screwdriver" with possession of both screwdrivers will ask player to disambiguate)
* Changed output text from unscrewing Ellie's computer case to state that the player has used a "screwdriver" to unlock the case, instead of specifically a Phillips Head Screwdriver
* Changed header test case "_ready coffee card" to also grab the flathead screwdriver, to test unlocking Ellie's computer
* Added new header test case "_get into ellies office", for easily testing screwdriver cases (assumes that "jimmying" the lock with the coffee card is functional)
* Added new test cases for unlocking Ellie's computer using different verbs, for both flathead and phillips head screwdriver.