### PR TITLE
Fixes #266: Add more acceptable phrases

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -135,39 +135,6 @@ Verb 'plunge'
 	* multiexcept 'with' held                   -> Plunge;
 
 
-[ IsSecurityCard;
-  return (noun == securityCard);
-];
-
-! This routine checks if player is in elevator and if they're trying
-! to scan the fob. If true, operates identically to inserting
-! fob into scanner in the tutorial.
-[ScanSub;
-    if (location ~= Tutorial) {
-
-		print "You see nothing to scan...";
-		return false;
-	}
-	if (noun == securityCard && securityCard hasnt heavy) {
-
-		print "You insert the fob into the scanner. The green lights happily flash a few times, and the door opens! You have completed the tutorial. To enter the game proper type ~north~ or ~n~. If you ever need help try the commands help or intro!";
-		give elevatorDoor open;
-		give elevatorDoor ~locked;
-	} 
-	if (noun==securityCard && securityCard has heavy) {
-		print "Oops, you fumble the fob and drop it on the floor of the elevator! Use ~take [object]~ to pick up an object. Try grabbing the fob and try again!";
-		give securityCard ~heavy;
-		move securityCard to Tutorial;
-		update_moved = True;
-	}
-
-	return true;
-];
-
-Verb 'scan'
-	* noun=IsSecurityCard						-> Scan; 
-
-
 Extend 'pick' first
 	* noun 'with' held                          -> Unlock
 	* 'apart'/'open' noun 'with' held           -> Unlock
@@ -290,6 +257,53 @@ with
 		}
 	],
 has heavy;
+
+
+! This routine checks if player is in elevator and if they're trying
+! to scan the fob. If true, operates identically to inserting
+! fob into scanner in the tutorial.
+[ScanSub;
+
+	! Return false if player tries to scan anything while outside elevator
+    if (location ~= Tutorial) {
+
+		print "You see nothing to scan...";
+		return false;
+	}
+
+	! (Almost) Same action as 'Receive' in Tutorial
+	if (noun == securityCard && securityCard hasnt heavy) {
+
+		! If the player tries to "insert fob into scanner" twice (w/o "take fob"), this message 
+		! is printed. For some reason PunyInform doesn't do that here, so doing it manually.
+		if (securityCard notin player) {
+			print "(first taking the Security Key Fob)";
+			new_line;
+		}
+		"You insert the fob into the scanner. The green lights happily flash a few times, and the door opens! You have completed the tutorial. To enter the game proper type ~north~ or ~n~. If you ever need help try the commands help or intro!";
+		give elevatorDoor open;
+		give elevatorDoor ~locked;
+	} 
+	if (noun==securityCard && securityCard has heavy) {
+		print "Oops, you fumble the fob and drop it on the floor of the elevator! Use ~take [object]~ to pick up an object. Try grabbing the fob and try again!";
+		give securityCard ~heavy;
+		move securityCard to Tutorial;
+	
+		! The PunyInform manual states to do this when changing an object's 
+		! location outside its scope, but we don't have OPTIONAL_MANUAL_SCOPE set.
+		
+		update_moved = True;
+	}
+
+	return true;
+];
+
+[ IsSecurityCard;
+  return (noun == securityCard);
+];
+
+Verb 'scan'
+	* noun=IsSecurityCard						-> Scan; 
 
 !===================LOBBY=======================
 Object Lobby "The Lobby"

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -146,6 +146,9 @@ Extend 'transfer' first
 Extend 'move' replace
 	* noun					    -> transfer;
 
+Extend 'show' replace
+	* noun 'to' noun			-> insert;
+
 ! 'screw' and 'unscrew' are defined as synonyms for 'turn',
 ! rather unhelpfully for a game that wishes to distinguish them.
 ! We keep that behaviour, and extend here.
@@ -161,6 +164,7 @@ Extend only 'turn' first
 
 Extend only 'remove' first
 	* noun 'with' held			    -> Remove;
+
 
 [Initialise;
   ! Start out VERBOSE instead of BRIEF

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -25,6 +25,7 @@ Constant OPTIONAL_PROVIDE_UNDO;
 Constant INITIAL_LOCATION_VALUE = Tutorial;
 Constant DEBUG;
 
+
 Constant voxfail = "The tower silently listens to your voice, but then flashes red and buzzes disapprovingly. Red text appears on a screen: ~YOU ARE NOT JOHN TITOR THIS LOGIN ATTEMPT WILL BE REPORTED.~";
 Constant handfail = "You place your hand on the handprint recognizer. Light scans your hand before flashing red and buzzing disapprovingly. Red text appears on a screen: ~YOU ARE NOT JOHN TITOR THIS LOGIN ATTEMPT WILL BE REPORTED.~";
 
@@ -112,6 +113,7 @@ Verb 'type'  * -> TypeErr
 		}
 	}
 ];
+
 	
 Verb 'hint' * -> Hint;
 
@@ -131,6 +133,40 @@ Verb 'plunge'
 	* noun=IsToilet                             -> Plunge
 	* noun                                      -> Plunge
 	* multiexcept 'with' held                   -> Plunge;
+
+
+[ IsSecurityCard;
+  return (noun == securityCard);
+];
+
+! This routine checks if player is in elevator and if they're trying
+! to scan the fob. If true, operates identically to inserting
+! fob into scanner in the tutorial.
+[ScanSub;
+    if (location ~= Tutorial) {
+
+		print "You see nothing to scan...";
+		return false;
+	}
+	if (noun == securityCard && securityCard hasnt heavy) {
+
+		print "You insert the fob into the scanner. The green lights happily flash a few times, and the door opens! You have completed the tutorial. To enter the game proper type ~north~ or ~n~. If you ever need help try the commands help or intro!";
+		give elevatorDoor open;
+		give elevatorDoor ~locked;
+	} 
+	if (noun==securityCard && securityCard has heavy) {
+		print "Oops, you fumble the fob and drop it on the floor of the elevator! Use ~take [object]~ to pick up an object. Try grabbing the fob and try again!";
+		give securityCard ~heavy;
+		move securityCard to Tutorial;
+		update_moved = True;
+	}
+
+	return true;
+];
+
+Verb 'scan'
+	* noun=IsSecurityCard						-> Scan; 
+
 
 Extend 'pick' first
 	* noun 'with' held                          -> Unlock
@@ -232,6 +268,8 @@ with
 	],
 	
 has light;
+
+
 
 Object -> elevatorDoor "Elevator Door"
 with
@@ -1357,6 +1395,10 @@ with
 				give ellieComputer open;
 				return true;
 			}
+			else if (second==flathead) {
+				print "You try to unscrew the screws with your flathead screwdriver, but it does not fit.";
+				return false;
+			}
 			else {
 				print "You should specify a tool you are turning the screws with.";
 				return true;
@@ -1367,6 +1409,10 @@ with
 				give ellieComputer ~locked;
 				give ellieComputer open;
 				return true;
+			}
+			else if (second==flathead) {
+				print "You try to unscrew the screws with your flathead screwdriver, but it does not fit.";
+				return false;
 			}
 			else {
 				print "You should specify a tool you are unscrewing the screws with.";

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -249,7 +249,7 @@ has static door ~open locked concealed;
 
 Object securityCard "Security Key Fob"
 with 
-	name 'security' 'fob' 'id' 'identification' 'pass' 'key',
+	name 'security' 'fob' 'id' 'identification' 'pass' 'key' 'card',
 	description [;
 		print "This is a small plastic key fob with a fake name you gave them during the hiring process. ";
 		if(player in Tutorial){

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -135,6 +135,13 @@ You insert the fob into the scanner.
 > show id to scanner
 You insert the fob into the scanner.
 
+* scan fob in tutorial
+> scan fob
+> take fob
+Taken.
+> scan fob
+You insert the fob into the scanner.
+
 * get/drop key from receptionist area
 
 > insert fob into scanner

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -74,6 +74,66 @@ You insert the fob into the scanner.
 > scan card
 (first taking the Security Key Fob)
 You insert the fob into the scanner.
+> undo
+> undo
+> insert id into scanner
+> insert id into scanner
+(first taking the Security Key Fob)
+You insert the fob into the scanner.
+> undo
+> undo
+> insert card into scanner
+> insert card into scanner
+(first taking the Security Key Fob)
+You insert the fob into the scanner.
+> undo
+> undo
+> insert fob into scanner
+> insert fob into scanner
+(first taking the Security Key Fob)
+You insert the fob into the scanner.
+> undo
+> undo
+> show fob to scanner
+> show fob to scanner
+(first taking the Security Key Fob)
+You insert the fob into the scanner.
+> undo
+> undo
+> show card to scanner
+> show card to scanner
+(first taking the Security Key Fob)
+You insert the fob into the scanner.
+> undo
+> undo
+> show id to scanner
+> show id to scanner
+(first taking the Security Key Fob)
+You insert the fob into the scanner.
+
+* insert card (fob) into scanner in Tutorial
+> insert card into scanner
+> take card
+> insert card into scanner
+You insert the fob into the scanner.
+
+* insert id (fob) into scanner in Tutorial
+> insert id into scanner
+> take card
+> insert id into scanner
+You insert the fob into the scanner.
+
+* show card (fob) to scanner in Tutorial
+> show card to scanner
+> take card
+> show card to scanner
+You insert the fob into the scanner.
+
+* show id (fob) to scanner in Tutorial
+> show id to scanner
+> take id
+> show id to scanner
+You insert the fob into the scanner.
 
 * get/drop key from receptionist area
 

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -56,6 +56,13 @@
 
 The Lobby
 
+* scan fob twice consecutively
+
+> scan fob
+> scan fob
+(first taking the Security Key Fob)
+You insert the fob into the scanner.
+
 * get/drop key from receptionist area
 
 > insert fob into scanner

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -62,6 +62,18 @@ The Lobby
 > scan fob
 (first taking the Security Key Fob)
 You insert the fob into the scanner.
+> undo
+> undo
+> scan id
+> scan id
+(first taking the Security Key Fob)
+You insert the fob into the scanner.
+> undo
+> undo
+> scan card
+> scan card
+(first taking the Security Key Fob)
+You insert the fob into the scanner.
 
 * get/drop key from receptionist area
 
@@ -636,6 +648,7 @@ The computer boots
 > s
 > s
 > jimmy door with card
+> coffee card
 You unlock the office door and open it!
 > e
 Ellie's Office


### PR DESCRIPTION
* Added new routine, "ScanSub", that allows the player to simply "scan fob" while inside the tutorial;
* Extended verb "show" to be synonymous with "insert" (for inserting fob into scanner);
* Added one test to ensure that additional dialogue is printed if the player attempts to scan their fob twice (without picking it up first);
* Added multiple tests for variations of "show" and "insert" fob/card/id into scanner, and a test for "scan fob"
* Changed one test that had an ambiguous reference to "card"