### PR TITLE
Fixes #284: "Some objects give descriptions rather than errors on actions"

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -808,8 +808,9 @@ with
 			default: "The door to the west office is locked. Maybe you could find a key or an alternate way in.";
 		]
 		'poster' 'kitten poster' [;
-			Take: "Unfortunately, simply taking down the poster will not spare the kitten. You decide to leave business-kitten to its fate.";
-			default: "The poster depicts an especially sad-looking kitten wearing a business suit with a tie, clinging helplessly to a branch. The poster is captioned with the words 'Hang In There!'.";
+			Take, Remove: "Unfortunately, simply taking down the poster will not spare the kitten. You decide to leave business-kitten to its fate.";
+			Examine, Look: "The poster depicts an especially sad-looking kitten wearing a business suit with a tie, clinging helplessly to a branch. The poster is captioned with the words 'Hang In There!'.";
+			default: "I'm not sure what you want me to do with business-kitten.";
 		],
 
 s_to Hallway6,

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -842,6 +842,25 @@ LOGIN INCORRECT
 presents you with a command prompt.
 
 
+* Interact with kitten poster
+> insert fob into scanner
+> insert fob into scanner
+> n
+> w
+> n
+> n
+> n
+> examine poster
+The poster depicts an especially sad-looking kitten wearing a business suit with a tie, clinging helplessly to a branch. The poster is captioned with the words 'Hang In There!'.
+> look poster
+The poster depicts an especially sad-looking kitten wearing a business suit with a tie, clinging helplessly to a branch. The poster is captioned with the words 'Hang In There!'.
+> take poster
+Unfortunately, simply taking down the poster will not spare the kitten.
+> remove poster
+Unfortunately, simply taking down the poster will not spare the kitten.
+> eat poster
+I'm not sure what you want me to do with business-kitten.
+
 * Easter Eggs
 > damn this stupid chunk of germanium
 DAMN.SV NOT FOUND


### PR DESCRIPTION
* Changed default case to indicate that the player has used a bad verb on poster
* Added verb "Examine" (to poster), functions same as "Look"
* Added verb "Remove" (to poster), functions same as "Take"
* Added tests for poster