### PR TITLE
Fixes #287: "Items dropped in darkness without flashlight are lost"

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -1337,6 +1337,12 @@ with
 
 	when_on "There is a flashlight here (turned on).",
 	when_off "There is a flashlight here (turned off).",
+	before [;
+		Drop: 
+			if (location hasnt light) {
+				"You abstain, given the pitch-blackness."; 
+			}
+	],
 	after [;
 		SwitchOn: give self light;
 		SwitchOff: give self ~light;

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -841,6 +841,77 @@ LOGIN INCORRECT
 > type jtitor into terminal then type tipler into terminal
 presents you with a command prompt.
 
+* Drop flashlight in dark area
+
+> insert fob into scanner
+> take fob
+> insert fob into scanner
+> n
+> e
+> n
+> n
+> w
+> get ladder
+Taken.
+> e
+> n
+> w
+> w
+> s
+> e
+> get torch
+Taken.
+> w
+> n
+> n
+> use ladder
+Ladders are very straightforward devices.
+> climb ladder
+You climb up the ladder.  However you had to leave it behind.
+Dropped.
+> d
+> s
+> e
+> e
+> take plant
+Taken.
+> get plant
+You already have it.
+> w
+> w
+> n
+> u
+You climb up the ladder.You couldn't possibly fit up there while carrying the large potted plant!
+You climb back down.
+> drop plant
+Dropped.
+> u
+pitch
+> turn on torch
+Crawl Space
+You climb up into a small crawl space
+!You're not sure how you can use that in this location.
+> d
+> climb ladder
+Crawl Space
+> drop flashlight
+You abstain, given the pitch-blackness.
+> drop flashlight
+You abstain, given the pitch-blackness.
+> turn off flashlight
+You switch the flashlight off
+> drop key
+Dropped.
+> take key
+You can't see any such thing.
+> turn on flashlight
+You switch the flashlight on
+> take key
+Taken.
+> turn off flashlight
+> drop flashlight
+You abstain, given the pitch-blackness.
+
 
 * Easter Eggs
 > damn this stupid chunk of germanium


### PR DESCRIPTION
Added a conditional to flashlight->Drop that returns an error if the player attempts to drop their flashlight in a dark room, + tests.

Dropping other items in darkness works like normal.