### PR TITLE
Fixes #282: "Moving objects in inventory causes programming error"

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -143,9 +143,6 @@ Extend 'pick' first
 Extend 'transfer' first
 	* noun 'to' noun		    -> transfer;
 
-Extend 'move' replace
-	* noun					    -> transfer;
-
 Extend 'show' replace
 	* noun 'to' noun			-> insert;
 

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -153,15 +153,12 @@ Extend 'pick' first
 Extend 'transfer' first
 	* noun 'to' noun		    -> transfer;
 
-<<<<<<< HEAD
-=======
 Extend 'move' first
 	* noun					    -> Move;
 
 Extend 'put' first
 	* noun 						-> Put;
 
->>>>>>> 45a4ec6125666821932d6546098bff83ef5a501e
 Extend 'show' replace
 	* noun 'to' noun			-> insert;
 

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -39,7 +39,7 @@
 
 * Try to move inventory items
 > move fob
-Nothing obvious happens.
+You should try to
 > insert fob into scanner
 > insert fob into scanner
 You insert the fob into the scanner.

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -37,6 +37,13 @@
 # > l
 # It feels so nice, standing in the box.
 
+* Try to move inventory items
+> move fob
+Nothing obvious happens.
+> insert fob into scanner
+> insert fob into scanner
+You insert the fob into the scanner.
+
 * loop the hallway
 
 > insert fob into scanner


### PR DESCRIPTION
Removed extension for verb 'move' as 'transfer', which was transitive. Added tests for moving key fob