### PR TITLE
Fixes #282: "Removing door to office 3 can't enter room afterwards bug Something isn't working"

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -986,14 +986,18 @@ with
 		'hinges' 'hinge' [;
 			Examine: "These hinges bind the door to the wall by four pins going through the entire assembly. Maybe you could remove the pins if you had something with a flat end to push them out.";
 			Remove: 
-							if(second==flathead){ 
+							if(second==flathead && Office3Door hasnt open){ 
 								print "You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...";
 								give Office3Door open;
-								give Office3Door concealed;	
 								return true;
 							}
-							else{
+							else if (Office3Door hasnt open) {
+
 								print "You try that, but it doesn't seem to work. Maybe you need something like a chisel.";
+								return true;
+							}
+							else {
+								print "The now-bent pins lay beside the fallen door. You see no point in taking them with you.";
 								return true;
 							};
 			default: "I am not sure what you want me to do.";
@@ -1001,14 +1005,18 @@ with
 		'pins' 'pin' [;
 			Examine: "These pins were hammered into place while someone held the door up. This is how most doors are attached to walls, it seems this door just so happens to have them on the exterior of the office.";
 			Take,Remove:
-							if(second==flathead){ 
+							if(second==flathead && Office3Door hasnt open){ 
 								print "You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...";
 								give Office3Door open;
 								return true;
 							}
-							else{
+							else if (Office3Door hasnt open) {
 
 								print "You try that, but it doesn't seem to work. Maybe you need something like a chisel.";
+								return true;
+							}
+							else {
+								print "The now-bent pins lay beside the fallen door. You see no point in taking them with you.";
 								return true;
 							};
 		!	default: "I am not sure what you want me to do.";

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -985,10 +985,31 @@ with
 		'water' 'water dispenser' "The water dispenser sits there, idle, empty and useless."
 		'hinges' 'hinge' [;
 			Examine: "These hinges bind the door to the wall by four pins going through the entire assembly. Maybe you could remove the pins if you had something with a flat end to push them out.";
-			Remove: 
+			Take, Remove: 
 							if(second==flathead && Office3Door hasnt open){ 
 								print "You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...";
 								give Office3Door open;
+								give Office3Door ~locked;
+								return true;
+							}
+							else if (Office3Door hasnt open) {
+
+								print "You try that, but it doesn't seem to work. Maybe you need something like a chisel.";
+								return true;
+							}
+							else {
+								print "The now-bent pins lay beside the fallen door. You see no point in taking them with you.";
+								return true;
+							};
+			! default: "I am not sure what you want me to do.";
+		]
+		'pins' 'pin'[;
+			Examine: "These pins were hammered into place while someone held the door up. This is how most doors are attached to walls, it seems this door just so happens to have them on the exterior of the office.";
+			Take,Remove:
+							if(second==flathead && Office3Door hasnt open){ 
+								print "You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...";
+								give Office3Door open;
+								give Office3Door ~locked;
 								return true;
 							}
 							else if (Office3Door hasnt open) {
@@ -1001,25 +1022,6 @@ with
 								return true;
 							};
 			default: "I am not sure what you want me to do.";
-		]
-		'pins' 'pin' [;
-			Examine: "These pins were hammered into place while someone held the door up. This is how most doors are attached to walls, it seems this door just so happens to have them on the exterior of the office.";
-			Take,Remove:
-							if(second==flathead && Office3Door hasnt open){ 
-								print "You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...";
-								give Office3Door open;
-								return true;
-							}
-							else if (Office3Door hasnt open) {
-
-								print "You try that, but it doesn't seem to work. Maybe you need something like a chisel.";
-								return true;
-							}
-							else {
-								print "The now-bent pins lay beside the fallen door. You see no point in taking them with you.";
-								return true;
-							};
-		!	default: "I am not sure what you want me to do.";
 		],
 w_to Hallway5,
 e_to Hallway3,

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -985,6 +985,8 @@ with
 		'water' 'water dispenser' "The water dispenser sits there, idle, empty and useless."
 		'hinges' 'hinge' [;
 			Examine: "These hinges bind the door to the wall by four pins going through the entire assembly. Maybe you could remove the pins if you had something with a flat end to push them out.";
+			
+			! We need to have 'take' here too. it resolves to the default 'remove' if 2nd arg isn't given
 			Take, Remove: 
 							if(second==flathead && Office3Door hasnt open){ 
 								print "You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...";

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -628,7 +628,7 @@ which contains Ellie's hard drive
 > take hard drive
 Taken.
 
-* Test Office3Door closing/opening door & removing/taking pins
+* Test Office3Door closing/opening door & removing/taking PINS
 > scan fob
 > scan fob
 > n
@@ -665,6 +665,45 @@ You can't lock that.
 > n
 > switch computer
 You boot the computer and are greeted by a password screen. You do not know the password to this computer so you decide to turn it off; maybe you could find a way around the password. You do remember that it is company policy to not encrypt hard drives.
+
+* Test Office3Door closing/opening door & removing/taking HINGES
+> scan fob
+> scan fob
+> n
+> w
+> n
+> n
+> n
+> n
+> take tarp
+As you fold up and take the tarp you notice underneath it there was a flathead screwdriver!
+> take screwdriver
+Taken.
+> s
+> e
+> n
+You can't, since the Large Wooden Door is closed.
+> remove hinge
+You try that, but
+> remove hinge with screwdriver
+You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...
+> remove hinge with screwdriver
+The now-bent pins
+> take hinge
+The now-bent pins
+> remove hinge
+The now-bent pins
+> close door
+You can't close that.
+> open door
+You can't open that.
+> lock door with screwdriver.
+You can't lock that.
+> n
+> n
+> switch computer
+You boot the computer and are greeted by a password screen. You do not know the password to this computer so you decide to turn it off; maybe you could find a way around the password. You do remember that it is company policy to not encrypt hard drives.
+
 
 * Complete game run with all tasks
 

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -628,18 +628,13 @@ which contains Ellie's hard drive
 > take hard drive
 Taken.
 
-* External USB boot drive
-> insert fob into scanner
-> take fob
-> insert fob into scanner
+* Test Office3Door closing/opening door & removing/taking pins
+> scan fob
+> scan fob
 > n
 > w
 > n
 > n
-> e
-> take drive
-Taken.
-> w
 > n
 > n
 > take tarp
@@ -654,13 +649,22 @@ You can't, since the Large Wooden Door is closed.
 You try that, but
 > remove pins with screwdriver
 You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...
+> remove pins with screwdriver
+The now-bent pins
+> take pins
+The now-bent pins
+> remove pins
+The now-bent pins
+> close door
+You can't close that.
+> open door
+You can't open that.
+> lock door with screwdriver.
+You can't lock that.
+> n
 > n
 > switch computer
 You boot the computer and are greeted by a password screen. You do not know the password to this computer so you decide to turn it off; maybe you could find a way around the password. You do remember that it is company policy to not encrypt hard drives.
-> insert drive into computer
-You insert the USB drive into the open port on the back of the computer.
-> switch computer
-The computer boots to a linux desktop, you bypassed the password! On the desktop there is a directory labeled "Secret Files". You are able to steal the information from the computer and save it onto the USB drive. After you pocket the USB drive, you must exfiltrate with this.
 
 * Complete game run with all tasks
 


### PR DESCRIPTION
* Fixed bug where door does not function properly once the hinges (specifically the hinges) are removed, causing a softlock
* Added new message for when the player attempts to remove the hinges a second time