### PR TITLE
297-more-synonyms-for-removing-pins

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -96,6 +96,11 @@ Verb 'type'  * -> TypeErr
 	noun = false; ! I think this suppresses an error message.
 ];
 
+![PrySub;
+!	print "You should try to ", (ul) "pry", " ", "something ", (ul) "with", " ", "something else.";
+!	noun = false;
+!];
+
 [TypeSub;
 	"That's not an object on which you can type anything.";
 ];
@@ -139,11 +144,14 @@ Verb 'jimmy' 'lift'
   return (noun == toilet);
 ];
 
+
 Verb 'plunge'
 	* noun=IsToilet                             -> Plunge
 	* noun                                      -> Plunge
 	* multiexcept 'with' held                   -> Plunge;
 
+Verb 'rip'
+	* 'off' noun 'with' held           -> Unlock;
 
 Extend 'pick' first
 	* noun 'with' held                          -> Unlock
@@ -159,6 +167,9 @@ Extend 'move' first
 Extend 'put' first
 	* noun 						-> Put;
 
+
+
+
 Extend 'show' replace
 	* noun 'to' noun			-> insert;
 
@@ -168,7 +179,7 @@ Extend 'show' replace
 ! Page 219 of the DM4 explains this syntax.
 Extend only 'unscrew' first
 	* noun 'with' held                          -> Unlock
-	* noun					    -> Unlock;
+	* noun					    				-> Unlock;
 Extend only 'screw' first
 	* noun 'with' held                          -> Lock;
 
@@ -177,6 +188,14 @@ Extend only 'turn' first
 
 Extend only 'remove' first
 	* noun 'with' held			    -> Remove;
+
+Extend only 'pry' first
+	* noun 'with' held 							-> Unlock
+	* 'apart'/'off' noun 'with' held           -> Unlock
+	* noun 										-> Unlock;
+Extend only 'pull' first
+	* 'apart'/'off' noun 'with' held           -> Unlock;
+
 
 
 [Initialise;
@@ -1003,42 +1022,44 @@ with
 			Examine: "These hinges bind the door to the wall by four pins going through the entire assembly. Maybe you could remove the pins if you had something with a flat end to push them out.";
 			
 			! We need to have 'take' here too. it resolves to the default 'remove' if 2nd arg isn't given
-			Take, Remove: 
-							if(second==flathead && Office3Door hasnt open){ 
+			Take,Remove,Unlock: 
+
+							if (Office3Door has open) {
+								print "The bent, useless pins lay beside the fallen door.";
+								return true;
+							}	
+							else if(second==flathead){ 
 								print "You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...";
 								give Office3Door open;
 								give Office3Door ~locked;
 								return true;
 							}
-							else if (Office3Door hasnt open) {
+							else {
 
 								print "You try that, but it doesn't seem to work. Maybe you need something like a chisel.";
 								return true;
 							}
-							else {
-								print "The now-bent pins lay beside the fallen door. You see no point in taking them with you.";
-								return true;
-							};
-			! default: "I am not sure what you want me to do.";
+			default: "I am not sure what you want me to do.";
 		]
 		'pins' 'pin'[;
 			Examine: "These pins were hammered into place while someone held the door up. This is how most doors are attached to walls, it seems this door just so happens to have them on the exterior of the office.";
-			Take,Remove:
-							if(second==flathead && Office3Door hasnt open){ 
+			Take,Remove,Unlock:
+
+							if (Office3Door has open) {
+								print "The bent, useless pins lay beside the fallen door.";
+								return true;
+							}
+							else if(second==flathead){ 
 								print "You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...";
 								give Office3Door open;
 								give Office3Door ~locked;
 								return true;
 							}
-							else if (Office3Door hasnt open) {
+							else {
 
 								print "You try that, but it doesn't seem to work. Maybe you need something like a chisel.";
 								return true;
 							}
-							else {
-								print "The now-bent pins lay beside the fallen door. You see no point in taking them with you.";
-								return true;
-							};
 			default: "I am not sure what you want me to do.";
 		],
 w_to Hallway5,

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -635,7 +635,7 @@ which contains Ellie's hard drive
 > take hard drive
 Taken.
 
-* Test Office3Door closing/opening door & removing/taking PINS
+* Test Office3Door closing/opening door & removing/taking pins/hinges
 > scan fob
 > scan fob
 > n
@@ -657,11 +657,40 @@ You try that, but
 > remove pins with screwdriver
 You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...
 > remove pins with screwdriver
-The now-bent pins
+The bent, useless
+> n
+This is an office. To the south there is a door leading back to the hallway.
+> undo
+> undo
+> undo
+> pry pins with screwdriver
+You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...
+> n
+This is an office. To the south there is a door leading back to the hallway.
+> undo
+> undo
+> pull off hinges with screwdriver
+You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...
+> n
+This is an office. To the south there is a door leading back to the hallway.
+> undo 
+> undo
+> rip off hinges with screwdriver
+You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...
+> n
+This is an office. To the south there is a door leading back to the hallway.
+> undo
+> undo
+> pry hinges with screwdriver
+You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...
+> pry pins with screwdriver
+The bent, useless
+> pry pins
+The bent, useless
 > take pins
-The now-bent pins
+The bent, useless
 > remove pins
-The now-bent pins
+The bent, useless
 > close door
 You can't close that.
 > open door
@@ -669,48 +698,7 @@ You can't open that.
 > lock door with screwdriver.
 You can't lock that.
 > n
-> n
-> switch computer
-You boot the computer and are greeted by a password screen. You do not know the password to this computer so you decide to turn it off; maybe you could find a way around the password. You do remember that it is company policy to not encrypt hard drives.
-
-* Test Office3Door closing/opening door & removing/taking HINGES
-> scan fob
-> scan fob
-> n
-> w
-> n
-> n
-> n
-> n
-> take tarp
-As you fold up and take the tarp you notice underneath it there was a flathead screwdriver!
-> take screwdriver
-Taken.
-> s
-> e
-> n
-You can't, since the Large Wooden Door is closed.
-> remove hinge
-You try that, but
-> remove hinge with screwdriver
-You remove the pins from the hinges of the door! The door falls forward with a loud *THUD* echoing through the halls...
-> remove hinge with screwdriver
-The now-bent pins
-> take hinge
-The now-bent pins
-> remove hinge
-The now-bent pins
-> close door
-You can't close that.
-> open door
-You can't open that.
-> lock door with screwdriver.
-You can't lock that.
-> n
-> n
-> switch computer
-You boot the computer and are greeted by a password screen. You do not know the password to this computer so you decide to turn it off; maybe you could find a way around the password. You do remember that it is company policy to not encrypt hard drives.
-
+This is an office. To the south there is a door leading back to the hallway.
 
 * Complete game run with all tasks
 


### PR DESCRIPTION
* Extended verbs 'pry (off/apart)' and 'pull (off/apart)' to unlock Office3Door pins; 
* Added new verb 'rip (off') with the same functionality as 'unlock'; reworded conditionals for Office3Door pins; 
* Added tests for verbs that extend 'unlock'; 
* Merged similar Office3Door tests into one extensive test."
* Minor bug fixes.

This one was tough t