### PR TITLE
296 exit but you arent in anything at the moment

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -1,6 +1,3 @@
-Array UUID_ARRAY string "UUID://XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX//";
-#Ifdef UUID_ARRAY;#Endif;
-
 Constant Story "One Night in San Francisco^^";
 Constant Headline "This is a work of ~interactive fiction~. ^^It is your first day on the job at Titor & Associates Financial Forecasting. You applied here to gain access to their offices after hours to steal their valuable information off of their computers. They have state of the art cyber security preventing any digital leaks of the information so you are here to physically take it.^^You step through the front doors of the office. It is pitch black outside. You are here after hours. As you walk through the quiet foyer, your shoes clack against the floor echoing revealing just how silent this space is after hours. You approach the elevator and press the up button. The elevator *DINGS* and the doors open. Entering the elevator, you press the button labeled ~13~, the floor of the office you are going to burgle tonight!^^The elevator hums as it brings you up to the floor requested, however upon reaching the 13th floor, the door does not open. A slot just below the floor buttons begins to light up requesting a security pass, which you were given upon your hiring.^^";
 

--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -1,3 +1,6 @@
+Array UUID_ARRAY string "UUID://XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX//";
+#Ifdef UUID_ARRAY;#Endif;
+
 Constant Story "One Night in San Francisco^^";
 Constant Headline "This is a work of ~interactive fiction~. ^^It is your first day on the job at Titor & Associates Financial Forecasting. You applied here to gain access to their offices after hours to steal their valuable information off of their computers. They have state of the art cyber security preventing any digital leaks of the information so you are here to physically take it.^^You step through the front doors of the office. It is pitch black outside. You are here after hours. As you walk through the quiet foyer, your shoes clack against the floor echoing revealing just how silent this space is after hours. You approach the elevator and press the up button. The elevator *DINGS* and the doors open. Entering the elevator, you press the button labeled ~13~, the floor of the office you are going to burgle tonight!^^The elevator hums as it brings you up to the floor requested, however upon reaching the 13th floor, the door does not open. A slot just below the floor buttons begins to light up requesting a security pass, which you were given upon your hiring.^^";
 
@@ -96,6 +99,11 @@ Verb 'type'  * -> TypeErr
 	noun = false; ! I think this suppresses an error message.
 ];
 
+[GoErrSub;
+	print "I think you wanted to say ~exit (some direction)~. Please try again.";
+	noun = false;
+];
+
 [TypeSub;
 	"That's not an object on which you can type anything.";
 ];
@@ -109,6 +117,7 @@ Verb 'type'  * -> TypeErr
 	print "You should try to ", (ul) "put", " ", "something ", (ul) "on", " something else";
 	noun = false; ! According to the guy above this suppresses an error msg
 ];
+
 
 
 [HintSub;
@@ -158,6 +167,10 @@ Extend 'move' first
 
 Extend 'put' first
 	* noun 						-> Put;
+
+Extend 'exit' replace
+	* noun=ADirection			-> Go
+	* multiexcept				-> GoErr;
 
 Extend 'show' replace
 	* noun 'to' noun			-> insert;
@@ -235,7 +248,7 @@ with
 
 	],
 	before [;
-		Go:
+		Go,Exit:
 			if(selected_direction==n_to && elevatorDoor has open){
 				PlayerTo(Lobby,2);
 				print "^You recall from your interview that the first office on the west side requires a brass key to open. To start maybe look for that key, or tackle any office you like first!";

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -588,6 +588,33 @@ which contains Ellie's hard drive
 > take hard drive
 Taken.
 
+
+* use exit to leave elevator
+> exit
+I think you wanted to say "exit (some direction)". Please try again.
+> exit n
+The elevator doors are still closed! Follow the tutorial to open them!
+> exit fob
+I think you wanted to say "exit (some direction)". Please try again.
+> exit elevator
+I think you wanted to say "exit (some direction)". Please try again.
+> exit elevator with fob
+> scan fob
+> scan fob
+> exit n
+The Lobby
+> exit s
+There is still critical information that isn't on you! You can't leave yet.
+> exit n
+Receptionist's Area
+> exit s
+The Lobby
+> exit n with
+I think you wanted to say "exit (some direction)". Please try again.
+> exit n to
+I think you wanted to say "exit (some direction)". Please try again.
+
+
 * pick to get hard drive
 >{include} _ready coffee card
 > pick lock with coffee card

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -598,7 +598,8 @@ The elevator doors are still closed! Follow the tutorial to open them!
 I think you wanted to say "exit (some direction)". Please try again.
 > exit elevator
 I think you wanted to say "exit (some direction)". Please try again.
-> exit elevator with fob
+> exit scanner
+No need to concern yourself with that.
 > scan fob
 > scan fob
 > exit n


### PR DESCRIPTION
* Replaced behavior of 'exit' with that of 'Go' (when noun is a direction); 
* Added routine 'GoErrSub' for all other cases (multiple nouns, nouns that aren't directions, etc.); 
* Added tests for Exit

I think I caught all possible uses of "exit" (w/ cheap scenery, multiple nouns, non-direction nouns, etc.). It's functionally identical to "go" now.