### PR TITLE
If the flashlight is dropped in a dark room (currently, only the 'Und…

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -1259,6 +1259,23 @@ has static door openable ~open lockable locked scenery;
 Object UnderItRoom "Under IT Room Crawlspace"
 with
 	description "You are underneath a raised floor. This cramped and dusty space is about one foot tall. Spaced every two feet are steel pillars; resting on top of the pillars are precisely fitted square floor tiles, held only by gravity. One tile has been removed. Ethernet wires run alongsize electrical condiut and air conditioning ducts. The part of the crawlspace you are in seems to be about the same size as the IT office, but the space extends far enough to the north that it disappears in darkness.",
+	before [;
+		Drop, Put:
+			if (noun == flashlight && flashlight has light) {
+				give self light;
+			}
+		Take:
+			if (noun == flashlight && self has flashlight && flashlight hasnt light) {
+				print "You fumble around in the darkness as you search for your flashlight, but it seems to have vanished into the pitch blackness. You'll have to find an exit without it.";
+				noun = false;
+			}
+	],
+	after [;
+		Take: 
+			if (noun == flashlight && flashlight has light) {
+				give self ~light;
+			}
+	],
 
 u_to Office2,
 n_to UnderServerRoom,
@@ -1271,7 +1288,23 @@ with
 Object UnderServerRoom "Under Server Room Crawlspace"
 with
 	description "You are underneath a raised floor. Dust bunnies are everywhere. Spaced every two feet are steel pillars; resting on top of the pillars are precisely fitted square floor tiles, held only by gravity. Light streams through holes in the tiles above your head; Ethernet cables snake through those holes into the light above. The muffled roar of server racks can be heard above your head. In the darkness to the south, a large square of light is visible.",
-
+	before [;
+		Drop, Put:
+			if (noun == flashlight && flashlight has light) {
+				give self light;
+			}
+		Take:
+			if (noun == flashlight && self has flashlight && flashlight hasnt light) {
+				print "You fumble around in the darkness as you search for your flashlight, but it seems to have vanished into the pitch blackness. You'll have to find an exit without it.";
+				noun = false;
+			}
+	],
+	after [;
+		Take: 
+			if (noun == flashlight && flashlight has light) {
+				give self ~light;
+			}
+	],
 u_to ServerRoom,
 s_to UnderITRoom;
 

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -455,9 +455,22 @@ You couldn't possibly fit
 Dropped.
 > d
 pitch dark
+> drop flashlight
+> take flashlight
+You fumble around
+> look
+pitch dark
+> undo
+> undo
 > turn on flashlight
 You switch the flashlight on.
 cramped and dusty space
+> drop flashlight
+> look
+You are underneath a raised floor.
+> take flashlight
+> look
+You are underneath a raised floor
 > n
 Dust bunnies
 > turn off flashlight


### PR DESCRIPTION
* If the player turns on the flashlight (currently just with 'Under' rooms) and the flashlight is off, then it will be lost for the rest of the game, and the player is warned that they'll need to 'find their way out without (a flashlight)'; 
* If the player drops the flashlight when it is toggled on, the room will be lit, and the player can pick up the flashlight.
* The rooms lose light again once the activated flashlight is picked up