### PR TITLE
Replace 'Futile.' with a nicer message. Fixes #91

### DIFF
--- a/untitledHeistGame.inf
+++ b/untitledHeistGame.inf
@@ -25,6 +25,9 @@ Constant OPTIONAL_PROVIDE_UNDO;
 Constant INITIAL_LOCATION_VALUE = Tutorial;
 Constant DEBUG;
 
+! defining constants we want to change
+Constant MSG_THROW_ANIMATE "That doesn't seem like it would be productive.";
+
 
 Constant voxfail = "The tower silently listens to your voice, but then flashes red and buzzes disapprovingly. Red text appears on a screen: ~YOU ARE NOT JOHN TITOR THIS LOGIN ATTEMPT WILL BE REPORTED.~";
 Constant handfail = "You place your hand on the handprint recognizer. Light scans your hand before flashing red and buzzing disapprovingly. Red text appears on a screen: ~YOU ARE NOT JOHN TITOR THIS LOGIN ATTEMPT WILL BE REPORTED.~";

--- a/untitledHeistGame.test
+++ b/untitledHeistGame.test
@@ -998,3 +998,13 @@ DAMN.SV NOT FOUND
 * Issue #258 test key fob name
 > examine security key fob
 This is a small plastic key fob with a fake name
+
+* Issue #91 -- "Futile." is a bad message
+> scan fob
+> scan fob
+> n
+> n
+> open desk
+> take key
+> throw key at desk
+That doesn't seem like it would be productive.


### PR DESCRIPTION
When you try to throw an animate object, it by default gives the error message "Futile." which doesn't communicate much. We had manually changed this in PunyInform's messages.h file on lars, but that is not a great way to fix the issue (it breaks updates to PunyInform due to the uncommitted change in messages.h).

SpaceHobo showed us how we can override that #define in messages.h with a Constant in untitledHeistGame.inf, which is what this commit does. I also added a test to ensure that the nicer message is displayed when an event that previously triggered "Futile." occurs (e.g., throwing the key at the desk).